### PR TITLE
Optimize the undefined match

### DIFF
--- a/src/nevernull.js
+++ b/src/nevernull.js
@@ -26,6 +26,11 @@ const nn = (rawValue)=>{
 };
 
 /**
+ * Cache the undefined version for speed.
+ */
+const undefinedNn = nn(undefined);
+
+/**
  * Proxy handler object.  Any time a property is read, get is executed first, allowing us to ensure the property value
  * is never null/undefined.
  * @type {{get: handler.get}}
@@ -45,7 +50,9 @@ const handler = {
     let rawPropertyValue = rawTarget ? rawTarget[name] : undefined;
 
     //function properties should maintain their context.
-    if(typeof rawPropertyValue === 'function'){
+    if(rawPropertyValue === undefined){
+      return undefinedNn;
+    }else if(typeof rawPropertyValue === 'function'){
       rawPropertyValue = rawPropertyValue.bind(rawTarget);
     }
 


### PR DESCRIPTION
Since we don't need multiple instances of this, why not reuse?